### PR TITLE
Implement the thread policy API

### DIFF
--- a/mach-test/build.rs
+++ b/mach-test/build.rs
@@ -287,7 +287,15 @@ fn main() {
         | "dyld_kernel_process_info"
         | "mach_timespec"
         | "mach_vm_read_entry"
-        | "mach_timebase_info" => format!("struct {}", ty),
+        | "mach_timebase_info"
+        | "thread_standard_policy"
+        | "thread_extended_policy"
+        | "thread_time_constraint_policy"
+        | "thread_precedence_policy"
+        | "thread_affinity_policy"
+        | "thread_background_policy"
+        | "thread_latency_qos_policy"
+        | "thread_throughput_qos_policy" => format!("struct {}", ty),
         _ if is_struct => format!("{}", ty),
         _ => ty.to_string(),
     });

--- a/mach-test/test/main.rs
+++ b/mach-test/test/main.rs
@@ -24,6 +24,7 @@ use mach2::structs::*;
 use mach2::task::*;
 use mach2::task_info::*;
 use mach2::thread_act::*;
+use mach2::thread_policy::*;
 use mach2::thread_status::*;
 use mach2::traps::*;
 use mach2::vm::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub mod structs;
 pub mod task;
 pub mod task_info;
 pub mod thread_act;
+pub mod thread_policy;
 pub mod thread_status;
 pub mod traps;
 pub mod vm;

--- a/src/thread_policy.rs
+++ b/src/thread_policy.rs
@@ -1,0 +1,127 @@
+//! This module corresponds to `mach/thread_policy.h`.
+
+use boolean::boolean_t;
+use kern_return::kern_return_t;
+use libc::thread_policy_t;
+use mach_types::thread_t;
+use message::mach_msg_type_number_t;
+use vm_types::{integer_t, natural_t};
+
+pub type thread_policy_flavor_t = natural_t;
+
+pub const THREAD_STANDARD_POLICY: thread_policy_flavor_t = 0;
+pub const THREAD_EXTENDED_POLICY: thread_policy_flavor_t = 1;
+pub const THREAD_TIME_CONSTRAINT_POLICY: thread_policy_flavor_t = 2;
+pub const THREAD_PRECEDENCE_POLICY: thread_policy_flavor_t = 3;
+pub const THREAD_AFFINITY_POLICY: thread_policy_flavor_t = 4;
+pub const THREAD_BACKGROUND_POLICY: thread_policy_flavor_t = 5;
+pub const THREAD_LATENCY_QOS_POLICY: thread_policy_flavor_t = 7;
+pub const THREAD_THROUGHPUT_QOS_POLICY: thread_policy_flavor_t = 8;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct thread_standard_policy {
+    pub _0: natural_t,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct thread_extended_policy {
+    pub timeshare: boolean_t,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct thread_time_constraint_policy {
+    pub period: u32,
+    pub computation: u32,
+    pub constraint: u32,
+    pub preemptible: boolean_t,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct thread_precedence_policy {
+    pub importance: integer_t,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct thread_affinity_policy {
+    pub affinity_tag: integer_t,
+}
+
+pub const THREAD_AFFINITY_TAG_NULL: integer_t = 0;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct thread_background_policy {
+    pub priority: integer_t,
+}
+
+pub type thread_latency_qos_t = integer_t;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct thread_latency_qos_policy {
+    thread_latency_qos_tier: thread_latency_qos_t,
+}
+
+pub type thread_throughput_qos_t = integer_t;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct thread_throughput_qos_policy {
+    thread_throughput_qos_tier: thread_throughput_qos_t,
+}
+
+pub type thread_standard_policy_data_t = thread_standard_policy;
+pub type thread_extended_policy_data_t = thread_extended_policy;
+pub type thread_time_constraint_policy_data_t = thread_time_constraint_policy;
+pub type thread_precedence_policy_data_t = thread_precedence_policy;
+pub type thread_affinity_policy_data_t = thread_affinity_policy;
+pub type thread_background_policy_data_t = thread_background_policy;
+pub type thread_latency_qos_policy_data_t = thread_latency_qos_policy;
+pub type thread_throughput_qos_policy_data_t = thread_throughput_qos_policy;
+
+pub const THREAD_STANDARD_POLICY_COUNT: mach_msg_type_number_t = 0;
+pub const THREAD_EXTENDED_POLICY_COUNT: mach_msg_type_number_t =
+    (core::mem::size_of::<thread_extended_policy>() /
+    core::mem::size_of::<integer_t>()) as _;
+pub const THREAD_TIME_CONSTRAINT_POLICY_DATA: mach_msg_type_number_t =
+    (core::mem::size_of::<thread_time_constraint_policy>() /
+    core::mem::size_of::<integer_t>()) as _;
+pub const THREAD_PRECEDENCE_POLICY_COUNT: mach_msg_type_number_t =
+    (core::mem::size_of::<thread_precedence_policy>() /
+    core::mem::size_of::<integer_t>()) as _;
+pub const THREAD_AFFINITY_POLICY_COUNT: mach_msg_type_number_t =
+    (core::mem::size_of::<thread_affinity_policy>() /
+    core::mem::size_of::<integer_t>()) as _;
+pub const THREAD_BACKGROUND_POLICY_COUNT: mach_msg_type_number_t =
+    (core::mem::size_of::<thread_background_policy>() /
+    core::mem::size_of::<integer_t>()) as _;
+pub const THREAD_LATENCY_QOS_POLICY_COUNT: mach_msg_type_number_t =
+    (core::mem::size_of::<thread_latency_qos_policy>() /
+    core::mem::size_of::<integer_t>()) as _;
+pub const THREAD_THROUGHPUT_QOS_POLICY_COUNT: mach_msg_type_number_t =
+    (core::mem::size_of::<thread_throughput_qos_policy>() /
+    core::mem::size_of::<integer_t>()) as _;
+
+extern "C" {
+    pub fn thread_policy_set(
+        thread: thread_t,
+        flavor: thread_policy_flavor_t,
+        policy_info: thread_policy_t,
+        count: mach_msg_type_number_t,
+    ) -> kern_return_t;
+}
+
+extern "C" {
+    pub fn thread_policy_get(
+        thread: thread_t,
+        flavor: thread_policy_flavor_t,
+        policy_info: thread_policy_t,
+        count: *mut mach_msg_type_number_t,
+        get_default: *mut boolean_t,
+    ) -> kern_return_t;
+}

--- a/src/thread_policy.rs
+++ b/src/thread_policy.rs
@@ -86,26 +86,20 @@ pub type thread_throughput_qos_policy_data_t = thread_throughput_qos_policy;
 
 pub const THREAD_STANDARD_POLICY_COUNT: mach_msg_type_number_t = 0;
 pub const THREAD_EXTENDED_POLICY_COUNT: mach_msg_type_number_t =
-    (core::mem::size_of::<thread_extended_policy>() /
-    core::mem::size_of::<integer_t>()) as _;
+    (core::mem::size_of::<thread_extended_policy>() / core::mem::size_of::<integer_t>()) as _;
 pub const THREAD_TIME_CONSTRAINT_POLICY_DATA: mach_msg_type_number_t =
-    (core::mem::size_of::<thread_time_constraint_policy>() /
-    core::mem::size_of::<integer_t>()) as _;
+    (core::mem::size_of::<thread_time_constraint_policy>() / core::mem::size_of::<integer_t>())
+        as _;
 pub const THREAD_PRECEDENCE_POLICY_COUNT: mach_msg_type_number_t =
-    (core::mem::size_of::<thread_precedence_policy>() /
-    core::mem::size_of::<integer_t>()) as _;
+    (core::mem::size_of::<thread_precedence_policy>() / core::mem::size_of::<integer_t>()) as _;
 pub const THREAD_AFFINITY_POLICY_COUNT: mach_msg_type_number_t =
-    (core::mem::size_of::<thread_affinity_policy>() /
-    core::mem::size_of::<integer_t>()) as _;
+    (core::mem::size_of::<thread_affinity_policy>() / core::mem::size_of::<integer_t>()) as _;
 pub const THREAD_BACKGROUND_POLICY_COUNT: mach_msg_type_number_t =
-    (core::mem::size_of::<thread_background_policy>() /
-    core::mem::size_of::<integer_t>()) as _;
+    (core::mem::size_of::<thread_background_policy>() / core::mem::size_of::<integer_t>()) as _;
 pub const THREAD_LATENCY_QOS_POLICY_COUNT: mach_msg_type_number_t =
-    (core::mem::size_of::<thread_latency_qos_policy>() /
-    core::mem::size_of::<integer_t>()) as _;
+    (core::mem::size_of::<thread_latency_qos_policy>() / core::mem::size_of::<integer_t>()) as _;
 pub const THREAD_THROUGHPUT_QOS_POLICY_COUNT: mach_msg_type_number_t =
-    (core::mem::size_of::<thread_throughput_qos_policy>() /
-    core::mem::size_of::<integer_t>()) as _;
+    (core::mem::size_of::<thread_throughput_qos_policy>() / core::mem::size_of::<integer_t>()) as _;
 
 extern "C" {
     pub fn thread_policy_set(

--- a/src/thread_policy.rs
+++ b/src/thread_policy.rs
@@ -9,7 +9,7 @@ use vm_types::{integer_t, natural_t};
 
 pub type thread_policy_flavor_t = natural_t;
 
-pub const THREAD_STANDARD_POLICY: thread_policy_flavor_t = 0;
+pub const THREAD_STANDARD_POLICY: thread_policy_flavor_t = 1;
 pub const THREAD_EXTENDED_POLICY: thread_policy_flavor_t = 1;
 pub const THREAD_TIME_CONSTRAINT_POLICY: thread_policy_flavor_t = 2;
 pub const THREAD_PRECEDENCE_POLICY: thread_policy_flavor_t = 3;
@@ -21,7 +21,7 @@ pub const THREAD_THROUGHPUT_QOS_POLICY: thread_policy_flavor_t = 8;
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct thread_standard_policy {
-    pub _0: natural_t,
+    pub no_data: natural_t,
 }
 
 #[repr(C)]
@@ -87,7 +87,7 @@ pub type thread_throughput_qos_policy_data_t = thread_throughput_qos_policy;
 pub const THREAD_STANDARD_POLICY_COUNT: mach_msg_type_number_t = 0;
 pub const THREAD_EXTENDED_POLICY_COUNT: mach_msg_type_number_t =
     (core::mem::size_of::<thread_extended_policy>() / core::mem::size_of::<integer_t>()) as _;
-pub const THREAD_TIME_CONSTRAINT_POLICY_DATA: mach_msg_type_number_t =
+pub const THREAD_TIME_CONSTRAINT_POLICY_COUNT: mach_msg_type_number_t =
     (core::mem::size_of::<thread_time_constraint_policy>() / core::mem::size_of::<integer_t>())
         as _;
 pub const THREAD_PRECEDENCE_POLICY_COUNT: mach_msg_type_number_t =


### PR DESCRIPTION
This PR implements part of the [thread policy API](https://opensource.apple.com/source/xnu/xnu-7195.81.3/osfmk/mach/thread_policy.h.auto.html) used to retrieve and request the policy for any given thread. More specifically, while this can be used to indicate to Mac OS that the thread is computationally intensive or rather a background thread, this API can also be used to set up latency-based or throughput-based QoS. Furthermore, Mac OS provides an affinity policy that allows one to indirectly set the affinity of threads to indicate whether certain CPU resources such as the L2 cache should or should not be shared between threads. Therefore, the affinity policy can be used as a hint to the scheduler for thread placement.