### PR TITLE
MacOS on Arm uses 16K pages instead of 4K pages

### DIFF
--- a/src/vm_page_size.rs
+++ b/src/vm_page_size.rs
@@ -29,6 +29,11 @@ mod tests {
             assert!(vm_page_size > 0);
             assert!(vm_page_size % 2 == 0);
             assert_eq!(mach_vm_round_page(1), vm_page_size as mach_vm_size_t);
+
+            #[cfg(target_arch = "aarch64")]
+            assert_eq!(vm_page_size, 16384);
+
+            #[cfg(not(target_arch = "aarch64"))]
             assert_eq!(vm_page_size, 4096);
         }
     }


### PR DESCRIPTION
This PR fixes a test case that assumes that the page size is 4K. However, Mac OS on the Apple M1 uses 16K pages instead of 4K pages:

```
$ uname -m
arm64
$ sysctl hw.pagesize
hw.pagesize: 16384
```