### PR TITLE
Add support for exceptions ports + aarch64

### DIFF
--- a/src/exc.rs
+++ b/src/exc.rs
@@ -2,7 +2,10 @@
 
 use exception_types::{exception_data_t, exception_type_t};
 use kern_return::kern_return_t;
-use message::mach_msg_type_number_t;
+use message::{
+    mach_msg_body_t, mach_msg_header_t, mach_msg_port_descriptor_t, mach_msg_type_number_t,
+};
+use ndr::NDR_record_t;
 use port::mach_port_t;
 use thread_status::thread_state_t;
 
@@ -41,4 +44,29 @@ extern "C" {
         new_state: thread_state_t,
         new_stateCnt: *mut mach_msg_type_number_t,
     ) -> kern_return_t;
+}
+
+#[repr(C)]
+#[allow(dead_code)]
+#[derive(Copy, Clone, Debug)]
+pub struct __Request__exception_raise_t {
+    pub Head: mach_msg_header_t,
+    /* start of the kernel processed data */
+    pub msgh_body: mach_msg_body_t,
+    pub thread: mach_msg_port_descriptor_t,
+    pub task: mach_msg_port_descriptor_t,
+    /* end of the kernel processed data */
+    pub NDR: NDR_record_t,
+    pub exception: exception_type_t,
+    pub codeCnt: mach_msg_type_number_t,
+    pub code: [i64; 2],
+}
+
+#[repr(C)]
+#[allow(dead_code)]
+#[derive(Copy, Clone, Debug)]
+pub struct __Reply__exception_raise_t {
+    pub Head: mach_msg_header_t,
+    pub NDR: NDR_record_t,
+    pub RetCode: kern_return_t,
 }

--- a/src/kern_return.rs
+++ b/src/kern_return.rs
@@ -1,6 +1,7 @@
-//! This module corresponds to `mach/kern_return.h` and
-//! `mach/i386/kern_return.h`.
+//! This module corresponds to `mach/kern_return.h`.
 
+// ...Except for this particular type, which is taken from `mach/i386/kern_return.h` and
+// `mach/arm/kern_return.h` (also used for aarch64): it is the same type in both header files.
 pub type kern_return_t = ::libc::c_int;
 
 pub const KERN_SUCCESS: kern_return_t = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub mod mach_time;
 pub mod mach_types;
 pub mod memory_object_types;
 pub mod message;
+pub mod ndr;
 pub mod port;
 pub mod structs;
 pub mod task;

--- a/src/ndr.rs
+++ b/src/ndr.rs
@@ -1,0 +1,19 @@
+//! This module roughly corresponds to `mach/ndr.h`.
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[allow(dead_code)]
+pub struct NDR_record_t {
+    mig_vers: libc::c_uchar,
+    if_vers: libc::c_uchar,
+    reserved1: libc::c_uchar,
+    mig_encoding: libc::c_uchar,
+    int_rep: libc::c_uchar,
+    char_rep: libc::c_uchar,
+    float_rep: libc::c_uchar,
+    reserved32: libc::c_uchar,
+}
+
+extern "C" {
+    pub static NDR_record: NDR_record_t;
+}

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,4 +1,4 @@
-//! This module corresponds to `mach/_structs.h`.
+//! This module corresponds to `mach/i386/_structs.h` and `mach/arm/_structs.h`.
 
 use mem;
 use message::mach_msg_type_number_t;
@@ -58,5 +58,27 @@ impl x86_thread_state64_t {
 
     pub fn count() -> mach_msg_type_number_t {
         (mem::size_of::<Self>() / mem::size_of::<::libc::c_int>()) as mach_msg_type_number_t
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
+pub struct arm_thread_state64_t {
+    pub __x: [u64; 29],
+    pub __fp: u64, // frame pointer x29
+    pub __lr: u64, // link register x30
+    pub __sp: u64, // stack pointer x31
+    pub __pc: u64,
+    pub __cpsr: u32,
+    pub __pad: u32,
+}
+
+impl arm_thread_state64_t {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn count() -> mach_msg_type_number_t {
+        (mem::size_of::<Self>() / mem::size_of::<u32>()) as mach_msg_type_number_t
     }
 }

--- a/src/task_info.rs
+++ b/src/task_info.rs
@@ -6,7 +6,7 @@ pub const TASK_INFO_MAX: ::libc::c_uint = 1024;
 pub const TASK_BASIC_INFO_32: ::libc::c_uint = 4;
 pub const TASK_BASIC2_INFO_32: ::libc::c_uint = 6;
 pub const TASK_BASIC_INFO_64: ::libc::c_uint = 5;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub const TASK_BASIC_INFO: ::libc::c_uint = 5;
 #[cfg(target_arch = "x86")]
 pub const TASK_BASIC_INFO: ::libc::c_uint = 4;

--- a/src/thread_act.rs
+++ b/src/thread_act.rs
@@ -1,8 +1,10 @@
 //! This module corresponds to `mach/thread_act.defs`.
 
+use exception_types::exception_mask_t;
 use kern_return::kern_return_t;
-use mach_types::thread_act_t;
+use mach_types::{thread_act_t, thread_port_t};
 use message::mach_msg_type_number_t;
+use port::mach_port_t;
 use thread_status::{thread_state_flavor_t, thread_state_t};
 
 extern "C" {
@@ -12,12 +14,23 @@ extern "C" {
         new_state: thread_state_t,
         new_state_count: *mut mach_msg_type_number_t,
     ) -> kern_return_t;
-}
 
-extern "C" {
+    pub fn thread_set_state(
+        target_act: thread_port_t,
+        flavor: thread_state_flavor_t,
+        new_state: thread_state_t,
+        new_stateCnt: mach_msg_type_number_t,
+    ) -> kern_return_t;
+
+    pub fn thread_set_exception_ports(
+        thread: thread_port_t,
+        exception_mask: exception_mask_t,
+        new_port: mach_port_t,
+        behavior: libc::c_uint,
+        new_flavor: thread_state_flavor_t,
+    ) -> kern_return_t;
+
     pub fn thread_suspend(target_act: thread_act_t) -> kern_return_t;
-}
 
-extern "C" {
     pub fn thread_resume(target_act: thread_act_t) -> kern_return_t;
 }

--- a/src/thread_status.rs
+++ b/src/thread_status.rs
@@ -17,7 +17,13 @@ pub static x86_EXCEPTION_STATE: thread_state_flavor_t = 9;
 pub static x86_DEBUG_STATE32: thread_state_flavor_t = 10;
 pub static x86_DEBUG_STATE64: thread_state_flavor_t = 11;
 pub static x86_DEBUG_STATE: thread_state_flavor_t = 12;
-pub static THREAD_STATE_NONE: thread_state_flavor_t = 13;
 pub static x86_AVX_STATE32: thread_state_flavor_t = 16;
 pub static x86_AVX_STATE64: thread_state_flavor_t = 17;
 pub static x86_AVX_STATE: thread_state_flavor_t = 18;
+
+pub static ARM_THREAD_STATE64: thread_state_flavor_t = 6;
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub static THREAD_STATE_NONE: thread_state_flavor_t = 13;
+#[cfg(target_arch = "aarch64")]
+pub static THREAD_STATE_NONE: thread_state_flavor_t = 5;

--- a/src/vm_types.rs
+++ b/src/vm_types.rs
@@ -1,4 +1,4 @@
-//! This module roughly corresponds to `mach/i386/vm_types.h`.
+//! This module roughly corresponds to `mach/i386/vm_types.h` and `mach/arm/vm_types.h` on aarch64.
 
 pub type natural_t = ::libc::c_uint;
 pub type integer_t = ::libc::c_int;


### PR DESCRIPTION
This adds enough support for https://github.com/bytecodealliance/wasmtime/pull/2632 to not add its own bindings, plus it brings up support for Apple Silicon (aarch64) by tweaking/adding a few data structures.

One note for reviewers: yes it's weird, but the count() implementations are indeed different when I look at my local mach header files. They are reflected as such in this PR.