### PR TITLE
Add the mach_msg_type_descriptor_t structure.

### DIFF
--- a/mach-test/build.rs
+++ b/mach-test/build.rs
@@ -133,6 +133,9 @@ fn main() {
     cfg.skip_struct(move |s| {
         match s {
             // TODO: this type is a bitfield and must be verified by hand
+            "mach_msg_type_descriptor_t" |
+
+            // TODO: this type is a bitfield and must be verified by hand
             "mach_msg_port_descriptor_t" |
 
             // TODO: this type is a bitfield and must be verified by hand

--- a/src/message.rs
+++ b/src/message.rs
@@ -165,6 +165,15 @@ pub struct mach_msg_trailer_t {
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
+pub struct mach_msg_type_descriptor {
+    pub pad1: natural_t,
+    pub pad2: mach_msg_size_t,
+    pub pad3: [u8; 3],
+    pub type_: u8, // mach_msg_descriptor_type_t bitfield
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct mach_msg_port_descriptor_t {
     pub name: mach_port_t,
     pub pad1: mach_msg_size_t,

--- a/src/message.rs
+++ b/src/message.rs
@@ -165,7 +165,7 @@ pub struct mach_msg_trailer_t {
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
-pub struct mach_msg_type_descriptor {
+pub struct mach_msg_type_descriptor_t {
     pub pad1: natural_t,
     pub pad2: mach_msg_size_t,
     pub pad3: [u8; 3],


### PR DESCRIPTION
Adds the mach_msg_type_descriptor_t structure that represents an untyped descriptor.

Also bumps the version since in my last pull request I've introduced a breaking change by changing a parameter in a public method (mach_msg_ool_descriptor_t::new).