### PR TITLE
Add mach_port_construct.

### DIFF
--- a/mach-test/build.rs
+++ b/mach-test/build.rs
@@ -133,6 +133,9 @@ fn main() {
     cfg.skip_struct(move |s| {
         match s {
             // TODO: this type is a bitfield and must be verified by hand
+            "mach_msg_type_descriptor_t" |
+
+            // TODO: this type is a bitfield and must be verified by hand
             "mach_msg_port_descriptor_t" |
 
             // TODO: this type is a bitfield and must be verified by hand

--- a/src/mach_port.rs
+++ b/src/mach_port.rs
@@ -3,7 +3,10 @@
 use kern_return::kern_return_t;
 use mach_types::ipc_space_t;
 use message::mach_msg_type_name_t;
-use port::{mach_port_delta_t, mach_port_name_t, mach_port_right_t, mach_port_t};
+use port::{
+    mach_port_delta_t, mach_port_name_t, mach_port_options_t, mach_port_right_t, mach_port_t,
+};
+use vm_types::mach_port_context_t;
 
 extern "C" {
     pub fn mach_port_allocate(
@@ -31,5 +34,11 @@ extern "C" {
         name: mach_port_name_t,
         right: mach_port_right_t,
         delta: mach_port_delta_t,
+    ) -> kern_return_t;
+    pub fn mach_port_construct(
+        task: ipc_space_t,
+        options: *mut mach_port_options_t,
+        context: mach_port_context_t,
+        name: *mut mach_port_name_t,
     ) -> kern_return_t;
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -165,6 +165,15 @@ pub struct mach_msg_trailer_t {
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
+pub struct mach_msg_type_descriptor {
+    pub pad1: natural_t,
+    pub pad2: mach_msg_size_t,
+    pub pad3: [u8; 3],
+    pub type_: u8, // mach_msg_descriptor_type_t bitfield
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct mach_msg_port_descriptor_t {
     pub name: mach_port_t,
     pub pad1: mach_msg_size_t,

--- a/src/message.rs
+++ b/src/message.rs
@@ -165,7 +165,7 @@ pub struct mach_msg_trailer_t {
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
-pub struct mach_msg_type_descriptor {
+pub struct mach_msg_type_descriptor_t {
     pub pad1: natural_t,
     pub pad2: mach_msg_size_t,
     pub pad3: [u8; 3],

--- a/src/port.rs
+++ b/src/port.rs
@@ -32,3 +32,35 @@ pub type mach_port_seqno_t = natural_t;
 pub type mach_port_mscount_t = natural_t;
 pub type mach_port_msgcount_t = natural_t;
 pub type mach_port_rights_t = natural_t;
+
+pub const MACH_PORT_QLIMIT_ZERO: mach_port_msgcount_t = 0;
+pub const MACH_PORT_QLIMIT_BASIC: mach_port_msgcount_t = 5;
+pub const MACH_PORT_QLIMIT_SMALL: mach_port_msgcount_t = 16;
+pub const MACH_PORT_QLIMIT_LARGE: mach_port_msgcount_t = 1024;
+pub const MACH_PORT_QLIMIT_KERNEL: mach_port_msgcount_t = 65534;
+pub const MACH_PORT_QLIMIT_MIN: mach_port_msgcount_t = MACH_PORT_QLIMIT_ZERO;
+pub const MACH_PORT_QLIMIT_DEFAULT: mach_port_msgcount_t = MACH_PORT_QLIMIT_BASIC;
+pub const MACH_PORT_QLIMIT_MAX: mach_port_msgcount_t = MACH_PORT_QLIMIT_LARGE;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
+pub struct mach_port_limits_t {
+    pub mpl_qlimit: mach_port_msgcount_t,
+}
+
+pub const MPO_CONTEXT_AS_GUARD: u32 = 1;
+pub const MPO_QLIMIT: u32 = 2;
+pub const MPO_TEMPOWNER: u32 = 4;
+pub const MPO_IMPORTANCE_RECEIVER: u32 = 8;
+pub const MPO_INSERT_SEND_RIGHT: u32 = 0x10;
+pub const MPO_STRICT: u32 = 0x20;
+pub const MPO_DENAP_RECEIVER: u32 = 0x40;
+pub const MPO_IMMOVABLE_RECEIVE: u32 = 0x80;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
+pub struct mach_port_options_t {
+    pub flags: u32,
+    pub mpl: mach_port_limits_t,
+    pub reserved: [u64; 2],
+}


### PR DESCRIPTION
Adds the mach_port_construct API and the required types.