### PR TITLE
Support `mach_init::mach_host_self`

### DIFF
--- a/examples/dump_process_registers.rs
+++ b/examples/dump_process_registers.rs
@@ -145,6 +145,8 @@ fn main() {
             thread_list as _,
             ((thread_count as usize) * mem::size_of::<libc::c_int>()) as _,
         );
+
+        println!("mach_host={:?}", mach2::mach_init::mach_host_self());
     }
 
     resume(task as task_t);

--- a/src/mach_init.rs
+++ b/src/mach_init.rs
@@ -4,6 +4,7 @@ use mach_types::thread_port_t;
 
 extern "C" {
     pub fn mach_thread_self() -> thread_port_t;
+    pub fn mach_host_self() -> thread_port_t;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I was looking for the replacement for the `libc::mach_host_self` https://github.com/rust-lang/libc/issues/4596 and found out the function is not declared in `mac_init`. So I add the declare for it.

Tested on my Apple m4 macOS with "Sequoia 15.2"
```
>  sudo ./target/debug/examples/dump_process_registers
Enter pid: 94756
pid = 94756
task = 0x1e03
Task is running 1 threads
Thread 0:
arm_thread_state64_t { __x: [4364289808, 1, 500, 68719460488, 82, 193, 202, 0, 8310391532, 8310434048, 0, 2, 0, 0, 56, 36920, 230, 105553178212160, 0, 4378997504, 1436528092462416, 500, 4364813416, 4377869200, 5392848604, 1, 4364813408, 428, 2], __fp: 6103525104, __lr: 4367684508, __sp: 6103525008, __pc: 6539245616, __cpsr: 0, __flags: 1 }
mach_host=6915
Success!
```

close https://github.com/JohnTitor/mach2/issues/34