### PR TITLE
refactor(structs): rename __flags field to __pad in arm_thread_state64_t

### DIFF
--- a/src/structs.rs
+++ b/src/structs.rs
@@ -13,7 +13,7 @@ pub struct arm_thread_state64_t {
     pub __sp: u64,
     pub __pc: u64,
     pub __cpsr: u32,
-    pub __flags: u32,
+    pub __pad: u32,
 }
 
 #[cfg(target_arch = "aarch64")]


### PR DESCRIPTION
`cargo test -p mach-test` fails on my machine:

```
cargo:warning=/Users/ldm0/repo/mach2/target/debug/build/mach-test-9bef3a60c86ed5b0/out/all.c:10023:12: error: no member named '__flags' in '__darwin_arm_thread_state64'
  cargo:warning= 10023 |     return offsetof(arm_thread_state64_t, __flags);
  cargo:warning=       |            ^                              ~~~~~~~
  cargo:warning=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/__stddef_offsetof.h:16:24: note: expanded from macro 'offsetof'
  cargo:warning=   16 | #define offsetof(t, d) __builtin_offsetof(t, d)
  cargo:warning=      |                        ^                     ~
  cargo:warning=/Users/ldm0/repo/mach2/target/debug/build/mach-test-9bef3a60c86ed5b0/out/all.c:10027:24: error: no member named '__flags' in 'struct __darwin_arm_thread_state64'
  cargo:warning= 10027 |     return sizeof(foo->__flags);
  cargo:warning=       |                   ~~~  ^
  cargo:warning=/Users/ldm0/repo/mach2/target/debug/build/mach-test-9bef3a60c86ed5b0/out/all.c:10030:16: error: no member named '__flags' in 'struct __darwin_arm_thread_state64'
  cargo:warning= 10030 |     return &b->__flags;
  cargo:warning=       |             ~  ^
  cargo:warning=3 errors generated.
```

After digging a little, I found that there is no `__flags` field: https://github.com/apple-oss-distributions/xnu/blob/e3723e1f17661b24996789d8afc084c0c3303b26/osfmk/mach/arm/_structs.h#L188