### PR TITLE
Add support for tvOS, watchOS and visionOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ include = ["src/**/*", "LICENSE-*", "README.md"]
 [badges]
 maintenance = { status = "passively-maintained" }
 
-[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+[target.'cfg(target_vendor = "apple")'.dependencies]
 libc = { version = "0.2", default-features = false }
 
 [features]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Rust interface to the **user-space** API of the Mach 3.0 kernel exposed in
 
 This library does not expose the **kernel-space** API of the Mach 3.0 kernel
 exposed in
-`SDK/System/Library/Frameworks/Kernel.framework/Versions/A/Headers/mach`. 
+`SDK/System/Library/Frameworks/Kernel.framework/Versions/A/Headers/mach`.
 
 That is, if you are writing a kernel-resident device drivers or some other
 kernel extensions you have to use something else. The user-space kernel API is
@@ -22,7 +22,7 @@ Add the following to your `Cargo.toml` to conditionally include mach on those
 platforms that support it.
 
 ```toml
-[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies.mach]
+[target.'cfg(target_vendor = "apple")'.dependencies.mach]
 version = "0.4"
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,8 @@
 )]
 #![no_std]
 
-#[cfg(not(any(target_os = "macos", target_os = "ios")))]
-compile_error!("mach requires macOS or iOS");
+#[cfg(not(target_vendor = "apple"))]
+compile_error!("mach requires macOS, iOS, tvOS, watchOS or visionOS");
 
 extern crate libc;
 


### PR DESCRIPTION
By using `cfg(target_vendor = "apple")` instead of `cfg(any(target_os = "macos", target_os = "ios"))`.

I suspect there may be a fairly large number of mach APIs which are likely to fail at runtime on these platforms - but that situation shouldn't be any different from iOS.