### PR TITLE
Update thread_get_state Parameter Names

### DIFF
--- a/src/thread_act.rs
+++ b/src/thread_act.rs
@@ -11,8 +11,8 @@ extern "C" {
     pub fn thread_get_state(
         target_act: thread_act_t,
         flavor: thread_state_flavor_t,
-        new_state: thread_state_t,
-        new_state_count: *mut mach_msg_type_number_t,
+        old_state: thread_state_t,
+        old_state_count: *mut mach_msg_type_number_t,
     ) -> kern_return_t;
 
     pub fn thread_set_state(


### PR DESCRIPTION
The correct names for the thread_get_state function parameters start with old instead of new. This helps reduce confusion when dealing with the function.

https://developer.apple.com/documentation/kernel/1418576-thread_get_state