### PR TITLE
Feat(traps): Add `task_name_for_pid`

### DIFF
--- a/src/traps.rs
+++ b/src/traps.rs
@@ -9,7 +9,7 @@ unsafe extern "C" {
     pub fn task_for_pid(
         target_tport: mach_port_name_t,
         pid: c_int,
-        tn: *mut mach_port_name_t,
+        t: *mut mach_port_name_t,
     ) -> kern_return_t;
 
     pub fn task_name_for_pid(

--- a/src/traps.rs
+++ b/src/traps.rs
@@ -5,7 +5,14 @@ use core::ffi::c_int;
 
 unsafe extern "C" {
     static mach_task_self_: mach_port_t;
+
     pub fn task_for_pid(
+        target_tport: mach_port_name_t,
+        pid: c_int,
+        tn: *mut mach_port_name_t,
+    ) -> kern_return_t;
+
+    pub fn task_name_for_pid(
         target_tport: mach_port_name_t,
         pid: c_int,
         tn: *mut mach_port_name_t,


### PR DESCRIPTION
This adds a new binding definition for the `task_name_for_pid` mach trap. It is defined here:
https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/osfmk/mach/mach_traps.h#L358-L361. It has the exact same API/ABI as `task_for_pid`, only the symbol name changes.

Also just passing by, the last argument of `task_for_pid` is renamed in order to match the original headers more closely (`t`) while the new `task_name_for_pid` uses its own (`tn`).